### PR TITLE
Update get_pdf_url.py

### DIFF
--- a/.github/workflows/build_and_deploy_with_secrets.yaml
+++ b/.github/workflows/build_and_deploy_with_secrets.yaml
@@ -36,29 +36,29 @@ jobs:
           sed -i "s/REPLACE_WITH_YOUR_API_KEY/$(echo "${{ secrets.ADOBE_API_KEY }}" | sed 's/\//\\\//g')/g" index.html
       # the extra lines take care of weird escape issues if they occur
 
-      # find the url of the pdf file in this repo
-      # - name: Install Python and dependencies
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install python3
-      #     python3 -m pip install --upgrade pip
-      #     python3 -m pip install requests beautifulsoup4
+      # Find the url of the pdf file in this repo
+      - name: Install Python and dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install python3
+          python3 -m pip install --upgrade pip
+          python3 -m pip install requests beautifulsoup4
 
-      # - name: Debug Workflow Environment
-      #   run: |
-      #     echo "Current directory: $(pwd)"
-      #     echo "Contents of current directory:"
-      #     ls -al
+      - name: Debug Workflow Environment
+        run: |
+          echo "Current directory: $(pwd)"
+          echo "Contents of current directory:"
+          ls -al
 
-      # - name: Get PDF URL
-      #   id: get_pdf_url
-      #   run: |
-      #     pdf_url_value=$(python get_pdf_url.py)
-      #     echo "PDF_URL=${pdf_url_value}" >> $GITHUB_ENV
+      - name: Get PDF URL
+        id: get_pdf_url
+        run: |
+          pdf_url_value=$(python get_pdf_url.py)
+          echo "PDF_URL=${pdf_url_value}" >> $GITHUB_ENV
 
-      # - name: Replace PDF file
-      #   run: |
-      #     sed -i "s/REPLACE_WITH_PDF_URL/$(echo "${{ env.PDF_URL }}" | sed 's/\//\\\//g')/g" index.html
+      - name: Replace PDF file
+        run: |
+          sed -i "s/REPLACE_WITH_PDF_URL/$(echo "${{ env.PDF_URL }}" | sed 's/\//\\\//g')/g" index.html
       
       - name: Debug Output
         run: cat index.html

--- a/.github/workflows/build_and_deploy_with_secrets.yaml
+++ b/.github/workflows/build_and_deploy_with_secrets.yaml
@@ -1,31 +1,21 @@
-# Build and deploy workflow
-
 name: Build and Deploy
 on:
-  # Triggers the workflow on push or pull request events but only for the "main" branch
   push:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
   workflow_dispatch:
-  # Allows you to run this workflow manually from the Actions tab
 permissions:
   contents: write
 
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains one job with two main steps: build and deploy
   build:
-    # The type of runner that the job will run on
     runs-on: ubuntu-latest
 
-    # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout
         uses: actions/checkout@v4
-        env: # Set Secret Key
+        env:
           secret_adobe_api_key: ${{ secrets.ADOBE_API_KEY }}
         
       - name: check if can even access key
@@ -34,9 +24,7 @@ jobs:
       - name: Replace API Key
         run: |
           sed -i "s/REPLACE_WITH_YOUR_API_KEY/$(echo "${{ secrets.ADOBE_API_KEY }}" | sed 's/\//\\\//g')/g" index.html
-      # the extra lines take care of weird escape issues if they occur
 
-      # Find the url of the pdf file in this repo
       - name: Install Python and dependencies
         run: |
           sudo apt-get update
@@ -66,10 +54,8 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          # Upload entire repository
           path: .
-        
-  # Deployment job
+
   deploy:
     permissions:
       id-token: write

--- a/get_pdf_url.py
+++ b/get_pdf_url.py
@@ -1,5 +1,6 @@
 import requests
 from bs4 import BeautifulSoup
+import sys
 
 def get_pdf_url(url):
     # Send a GET request to the specified URL
@@ -15,17 +16,18 @@ def get_pdf_url(url):
         if div_tag:
             # Extract the value of the data-file attribute
             pdf_url = div_tag.get('data-file')
-            return pdf_url
+            if pdf_url:
+                print(pdf_url)
+                return
+            else:
+                print("Data-file attribute not found.", file=sys.stderr)
         else:
-            print("Div tag with class 'pdf-container loaded' not found.")
+            print("Div tag with class 'pdf-container loaded' not found.", file=sys.stderr)
     else:
-        print(f"Failed to fetch the URL. Status code: {response.status_code}")
+        print(f"Failed to fetch the URL. Status code: {response.status_code}", file=sys.stderr)
+
+    sys.exit(1)
 
 # Example usage
 url = "https://github.com/jthaller/resume_url_hosting/blob/main/Jeremy_Thaller_Resume.pdf"
-pdf_url = get_pdf_url(url)
-
-if pdf_url:
-    print(f"The PDF URL is: {pdf_url}")
-else:
-    print("Failed to retrieve the PDF URL.")
+get_pdf_url(url)

--- a/get_pdf_url.py
+++ b/get_pdf_url.py
@@ -1,8 +1,7 @@
 import requests
 from bs4 import BeautifulSoup
-import json
 
-def get_dynamic_pdf_url(url):
+def get_pdf_url(url):
     # Send a GET request to the specified URL
     response = requests.get(url)
 
@@ -11,31 +10,22 @@ def get_dynamic_pdf_url(url):
         # Parse the HTML content using BeautifulSoup
         soup = BeautifulSoup(response.content, 'html.parser')
 
-        # Find the script tag with the specified data-target attribute
-        script_tag = soup.find('script', {'data-target': 'react-app.embeddedData'})
-        if script_tag:
-            # Extract the content of the script tag
-            script_content = script_tag.string
-
-            # Parse the JSON content
-            try:
-                json_data = json.loads(script_content)
-                
-                # Extract the PDF URL from the JSON
-                pdf_url = json_data['payload']['fileTree']['']['items'][2]['path']
-                return f"https://github.com/jthaller/resume_url_hosting/raw/main/{pdf_url}"
-            except json.JSONDecodeError as e:
-                print(f"Failed to parse JSON: {e}")
+        # Find the div tag with the class 'pdf-container loaded'
+        div_tag = soup.find('div', class_='pdf-container loaded')
+        if div_tag:
+            # Extract the value of the data-file attribute
+            pdf_url = div_tag.get('data-file')
+            return pdf_url
         else:
-            print("Script tag with data-target 'react-app.embeddedData' not found.")
+            print("Div tag with class 'pdf-container loaded' not found.")
     else:
         print(f"Failed to fetch the URL. Status code: {response.status_code}")
 
 # Example usage
-url = "view-source:https://github.com/jthaller/resume_url_hosting/blob/main/Jeremy_Thaller_Resume.pdf"
-dynamic_pdf_url = get_dynamic_pdf_url(url)
+url = "https://github.com/jthaller/resume_url_hosting/blob/main/Jeremy_Thaller_Resume.pdf"
+pdf_url = get_pdf_url(url)
 
-if dynamic_pdf_url:
-    print(f"The dynamic PDF URL is: {dynamic_pdf_url}")
+if pdf_url:
+    print(f"The PDF URL is: {pdf_url}")
 else:
-    print("Failed to retrieve the dynamic PDF URL.")
+    print("Failed to retrieve the PDF URL.")

--- a/get_pdf_url.py
+++ b/get_pdf_url.py
@@ -1,33 +1,27 @@
 import requests
-from bs4 import BeautifulSoup
 import sys
 
-def get_pdf_url(url):
-    # Send a GET request to the specified URL
+def get_latest_commit_sha(repo, branch='main'):
+    url = f"https://api.github.com/repos/{repo}/commits/{branch}"
     response = requests.get(url)
-
-    # Check if the request was successful (status code 200)
+    
     if response.status_code == 200:
-        # Parse the HTML content using BeautifulSoup
-        soup = BeautifulSoup(response.content, 'html.parser')
-
-        # Find the div tag with the class 'pdf-container loaded'
-        div_tag = soup.find('div', class_='pdf-container loaded')
-        if div_tag:
-            # Extract the value of the data-file attribute
-            pdf_url = div_tag.get('data-file')
-            if pdf_url:
-                print(pdf_url)
-                return
-            else:
-                print("Data-file attribute not found.", file=sys.stderr)
+        commit_sha = response.json().get('sha')
+        if commit_sha:
+            return commit_sha
         else:
-            print("Div tag with class 'pdf-container loaded' not found.", file=sys.stderr)
+            print("Commit SHA not found.", file=sys.stderr)
     else:
-        print(f"Failed to fetch the URL. Status code: {response.status_code}", file=sys.stderr)
+        print(f"Failed to fetch the latest commit. Status code: {response.status_code}", file=sys.stderr)
 
     sys.exit(1)
 
-# Example usage
-url = "https://github.com/jthaller/resume_url_hosting/blob/main/Jeremy_Thaller_Resume.pdf"
-get_pdf_url(url)
+def get_pdf_url(latest_commit_hash: str) -> str:
+    return f"https://raw.githubusercontent.com/jthaller/resume_url_hosting/{latest_commit_hash}/Jeremy_Thaller_Resume.pdf"
+
+
+if __name__ == "__main__":
+    repo = "jthaller/resume_url_hosting"
+    latest_commit_hash = get_latest_commit_sha(repo)
+    pdf_url = get_pdf_url(latest_commit_hash)
+    print(pdf_url)  # Print the PDF URL to capture it in the GitHub Actions workflow

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
 <div id="adobe-dc-view"></div>
 <script src="https://documentcloud.adobe.com/view-sdk/main.js"></script>
 <script type="text/javascript">
-	const pdf_url = "https://raw.githubusercontent.com/jthaller/resume_url_hosting/b6708d94488935385c433485118728f3afe0c44e/Jeremy_Thaller_Resume.pdf"
+	const pdf_url = "REPLACE_WITH_PDF_URL"
 	const api_key = "REPLACE_WITH_YOUR_API_KEY" //process.env.secret_adobe_api_key
 	document.addEventListener("adobe_dc_view_sdk.ready", function(){ 
 		var adobeDCView = new AdobeDC.View({clientId: api_key, divId: "adobe-dc-view"});


### PR DESCRIPTION
This now automatically detects what the new pdf url is to allow the adobe pdf viewer to retrieve it. This way, when you upload a new pdf, you don't need to also update the `index.html` to point to it; instead, the workflow actions detects the expected url via a python script, and then replaces the url value in the `index.html`